### PR TITLE
Replace "w" by "wb" when writing binary file

### DIFF
--- a/main.cpp
+++ b/main.cpp
@@ -408,7 +408,13 @@ static void save_file(unsigned char* data, const char* filename, int filesize, i
 {
     int i = 0;
     int x = 0;
-    FILE* f = ImFileOpen(filename, "w");
+    FILE* f;
+    if (format == FMT_BINARY)
+    {
+        f = ImFileOpen(filename, "wb");
+    } else {
+        f = ImFileOpen(filename, "w");
+    }
 
     // Not sure if the compiler takes care of this, but I'll optimize the loop anyway
     switch(format)


### PR DESCRIPTION
When saving a file in binary format, opens the file in binary mode.

This solves a compatibility problem on Windows when saving a binary file that contains a `\n` (`0xa`) byte, because windows automatically injects an additional `\r` (`0xd`) in the binary file.
The proposed patch does not modify the code path when dealing with other file formats, since it has not been tested.

Great tool, by the way!

Cheers, 